### PR TITLE
Fix windows keyboard shortcuts

### DIFF
--- a/packages/graphql-playground-electron/src/main/menu.ts
+++ b/packages/graphql-playground-electron/src/main/menu.ts
@@ -35,13 +35,13 @@ export const buildTemplate = (
       { type: 'separator' },
       {
         label: 'Settings',
-        accelerator: 'Command+,',
+        accelerator: 'CmdOrCtrl+,',
         click: () => send('Tab', 'Settings'),
       },
       { type: 'separator' },
       {
         label: 'Quit',
-        accelerator: 'Command+Q',
+        accelerator: 'CmdOrCtrl+Q',
         click: () => app.quit(),
       },
     ],
@@ -51,40 +51,40 @@ export const buildTemplate = (
     submenu: [
       {
         label: 'New Workspace',
-        accelerator: 'Cmd+N',
+        accelerator: 'CmdOrCtrl+N',
         click: () => {
           createWindow(windowContext)
         },
       },
       {
         label: 'New Tab',
-        accelerator: 'Cmd+T',
+        accelerator: 'CmdOrCtrl+T',
         click: () => send('Tab', 'New'),
       },
       { type: 'separator' },
       {
         label: 'Close Workspace',
-        accelerator: 'Cmd+Shift+W',
+        accelerator: 'CmdOrCtrl+Shift+W',
         role: 'close',
       },
       {
         label: 'Close Tab',
-        accelerator: 'Cmd+W',
+        accelerator: 'CmdOrCtrl+W',
         click: () => send('Tab', 'Close'),
       },
       {
         label: 'Open File',
-        accelerator: 'Cmd+O',
+        accelerator: 'CmdOrCtrl+O',
         click: () => send('File', 'Open'),
       },
       {
         label: 'Save File',
-        accelerator: 'Cmd+S',
+        accelerator: 'CmdOrCtrl+S',
         click: () => send('File', 'Save'),
       },
       {
         label: 'Reload Schema',
-        accelerator: 'Cmd+R',
+        accelerator: 'CmdOrCtrl+R',
         click: () => send('Tab', 'ReloadSchema'),
       },
     ],
@@ -130,17 +130,17 @@ export const buildTemplate = (
     submenu: [
       {
         label: 'Next Tab',
-        accelerator: 'Cmd+Alt+Right',
+        accelerator: 'CmdOrCtrl+Alt+Right',
         click: () => send('Tab', 'Next'),
       },
       {
         label: 'Previous Tab',
-        accelerator: 'Cmd+Alt+Left',
+        accelerator: 'CmdOrCtrl+Alt+Left',
         click: () => send('Tab', 'Next'),
       },
       {
         label: 'Minimize',
-        accelerator: 'Cmd+M',
+        accelerator: 'CmdOrCtrl+M',
         click: () => {
           const focusedWindow = BrowserWindow.getFocusedWindow()
           if (focusedWindow) {


### PR DESCRIPTION
We don't have `Cmd` available on windows :wink:

Fixes #513 .

Changes proposed in this pull request:

- Use `CmdOrCtrl` instead of `Cmd` to support windows shortcuts syntax


Note: I can't test on my computer due to some issue with the webpack configuration…

Ref: https://github.com/electron/electron/blob/master/docs/tutorial/keyboard-shortcuts.md