### PR TITLE
Initial stab at querystring in url

### DIFF
--- a/packages/graphql-playground-react/src/components/GraphQLBinApp.tsx
+++ b/packages/graphql-playground-react/src/components/GraphQLBinApp.tsx
@@ -31,6 +31,7 @@ export interface Props {
 export interface State {
   endpoint?: string
   subscriptionEndpoint?: string
+  query?: string
   shareUrl?: string
   loading: boolean
 }
@@ -108,8 +109,11 @@ class GraphQLBinApp extends React.Component<Props & ReduxProps, State> {
   }
 
   render() {
-    let { endpoint, subscriptionEndpoint } = this.state
+    let { endpoint, subscriptionEndpoint, query } = this.state
     // If no  endpoint passed tries to get one from url
+    if (!query) {
+      query = getParameterByName('query')
+    }
     if (!endpoint) {
       endpoint = getParameterByName('endpoint')
     }
@@ -141,6 +145,7 @@ class GraphQLBinApp extends React.Component<Props & ReduxProps, State> {
           <PlaygroundWrapper
             endpoint={endpoint}
             subscriptionEndpoint={subscriptionEndpoint}
+            query={query}
           />
         )}
       </div>

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -153,7 +153,6 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
 
     setLinkCreator(props.createApolloLink)
     this.getSchema()
-    this.getQuery()
     setSubscriptionEndpoint(props.subscriptionEndpoint)
   }
 
@@ -206,13 +205,6 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
     if (nextProps.configString !== this.props.configString) {
       this.props.setConfigString(nextProps.configString)
     }
-  }
-
-  getQuery(props = this.props) {
-    if (this.mounted && this.state.query) {
-      this.setState({ query: undefined })
-    }
-    this.setState({ query: props.query })
   }
 
   async getSchema(props = this.props) {

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -67,6 +67,7 @@ export interface Props {
   onChangeEndpoint?: (endpoint: string) => void
   share: (state: any) => void
   shareUrl?: string
+  query?: string
   onChangeSubscriptionsEndpoint?: (endpoint: string) => void
   getRef?: (ref: Playground) => void
   graphqlConfig?: any
@@ -113,6 +114,7 @@ export interface ReduxProps {
 
 export interface State {
   schema?: GraphQLSchema
+  query?: string
 }
 
 export interface CursorPosition {
@@ -124,7 +126,8 @@ export { GraphQLEditor }
 
 export class Playground extends React.PureComponent<Props & ReduxProps, State> {
   static defaultProps = {
-    shareEnabled: true,
+    shareEnabled: false,
+    query: undefined,
   }
 
   apolloLinks: { [sessionId: string]: any } = {}
@@ -140,6 +143,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
 
     this.state = {
       schema: undefined,
+      query: props.query,
     }
     ;(global as any).p = this
 
@@ -149,6 +153,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
 
     setLinkCreator(props.createApolloLink)
     this.getSchema()
+    this.getQuery()
     setSubscriptionEndpoint(props.subscriptionEndpoint)
   }
 
@@ -201,6 +206,13 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
     if (nextProps.configString !== this.props.configString) {
       this.props.setConfigString(nextProps.configString)
     }
+  }
+
+  getQuery(props = this.props) {
+    if (this.mounted && this.state.query) {
+      this.setState({ query: undefined })
+    }
+    this.setState({ query: props.query })
   }
 
   async getSchema(props = this.props) {
@@ -284,6 +296,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
               <GraphQLEditor
                 shareEnabled={this.props.shareEnabled}
                 schema={this.state.schema}
+                query={this.state.query}
               />
             )}
           </GraphiqlWrapper>

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -69,6 +69,7 @@ export interface Props {
   onRef?: any
   shareEnabled?: boolean
   schema?: GraphQLSchema
+  query?: string
 }
 
 export interface ReduxProps {
@@ -268,6 +269,7 @@ class GraphQLEditor extends React.PureComponent<
                 onHintInformationRender={this.handleHintInformationRender}
                 onRunQuery={this.runQueryAtCursor}
                 onClickReference={this.handleClickReference}
+                query={this.props.query}
               />
               <div
                 className="variable-editor"

--- a/packages/graphql-playground-react/src/components/Playground/QueryEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/QueryEditor.tsx
@@ -31,6 +31,7 @@ import {
  *
  */
 export interface Props {
+  query?: string
   schema?: GraphQLSchema | null
   onHintInformationRender?: (elem: any) => void
   onRunQuery?: () => void
@@ -97,7 +98,7 @@ export class QueryEditor extends React.PureComponent<Props & ReduxProps, {}> {
 
     this.editor = CodeMirror(this.node, {
       autofocus: true,
-      value: this.props.value || '',
+      value: this.props.query || this.props.value || '',
       lineNumbers: true,
       tabSize: 2,
       mode: 'graphql',

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -30,6 +30,7 @@ function getParameterByName(name: string, uri?: string): string | null {
 
 export interface PlaygroundWrapperProps {
   endpoint?: string
+  query?: string
   endpointUrl?: string
   subscriptionEndpoint?: string
   setTitle?: boolean
@@ -64,6 +65,7 @@ export interface State {
   activeProjectName?: string
   activeEnv?: string
   headers?: any
+  query?: string
 }
 
 class PlaygroundWrapper extends React.Component<
@@ -86,6 +88,8 @@ class PlaygroundWrapper extends React.Component<
       props.endpointUrl ||
       getParameterByName('endpoint') ||
       location.href
+
+    const query = props.query
 
     const result = this.extractEndpointAndHeaders(endpoint)
     endpoint = result.endpoint
@@ -118,6 +122,7 @@ class PlaygroundWrapper extends React.Component<
       activeEnv,
       activeProjectName: projectName,
       headers,
+      query,
     }
   }
 
@@ -312,6 +317,7 @@ class PlaygroundWrapper extends React.Component<
                 adminAuthToken={this.state.platformToken}
                 getRef={this.getPlaygroundRef}
                 config={this.props.config!}
+                query={this.state.query}
                 configString={this.state.configString!}
                 configIsYaml={this.state.configIsYaml!}
                 canSaveConfig={Boolean(this.props.canSaveConfig)}

--- a/packages/graphql-playground-react/src/types.ts
+++ b/packages/graphql-playground-react/src/types.ts
@@ -19,5 +19,5 @@ export interface ISettings {
   ['editor.theme']: Theme
   ['editor.reuseHeaders']: boolean
   ['tracing.hideTracingResponse']: boolean
-  ['request.credentials']: "omit" | "include" | "same-origin"
+  ['request.credentials']: 'omit' | 'include' | 'same-origin'
 }


### PR DESCRIPTION
Related to #301 and #487

I am very new to react - I'm not sure where the state should exist, what is being leaked where. I'm sure there's dead code.

This is just to start a discussion around being able to pass in a query string.

Some questions:
1. Should GraphQLBinApp even be the entry point for `getParameterByName('query')`?
2. How come the GraphiQL react component doesn't do this by default? 
3. Why does graphql-playground even need to know about the query and pass it down?
4. Is passing in the query string, layer by layer, prop by prop, really the best way? It seems super fragile and leaky.
5. How does redux fit into all of this?

Thanks for helping a beginner out.

