### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ cache:
   - $HOME/.cache/electron
   - $HOME/.cache/electron-builder
 
+git:
+  depth: 5
+
 install:
   - |
     security create-keychain -p travis build.keychain


### PR DESCRIPTION
Changes proposed in this pull request:

- clone only the last 5 commits. By default Travis CI clones the last 50 commits. 5 should be sufficient and faster.