### PR TITLE
Fix docs for usage as a React component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,13 @@ Including stylesheet and the component (`2., 3.`)
 ```js
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Playground from 'graphql-playground-react'
+import { Provider } from 'react-redux'
+import { Playground, store } from 'graphql-playground-react'
 
 ReactDOM.render(
-  <Playground endpoint="https://api.graph.cool/simple/v1/swapi" />,
+  <Provider store={store}>
+    <Playground endpoint="https://api.graph.cool/simple/v1/swapi" />
+  </Provider>,
   document.body,
 )
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

The example in the README for using the library as a React component appears to be incorrect or out-of-date and results in this error:

> Could not find "store" in either the context or props of "Connect(PlaygroundWrapper)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(PlaygroundWrapper)".

This PR fixes the problem and is modeled on the way the store is passed in the [Electron package](https://github.com/prismagraphql/graphql-playground/blob/master/packages/graphql-playground-electron/src/renderer/components/Root.tsx).