### PR TITLE
Nuke console.log from fetchingSagas.ts

### DIFF
--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -137,7 +137,7 @@ function* runQuerySaga(action) {
     headers,
     credentials: settings['request.credentials'],
   }
-  console.log({ lol })
+  
   const { link, subscriptionClient } = linkCreator(lol)
   yield put(setCurrentQueryStartTime(new Date()))
 


### PR DESCRIPTION
This PR removes an unnecessary `console.log` call in `fetchingSagas.ts`