### PR TITLE
Output 'result' from apollo-link-http error

### DIFF
--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -237,6 +237,11 @@ export function formatError(error, fetchingSchema: boolean = false) {
 
 function extractMessage(error) {
   if (error instanceof Error) {
+    // Errors from apollo-link-http may include a "result" object, which is a JSON response from
+    // the server. We should surface that to the client
+    if (!!error['result'] && typeof error['result'] === 'object') {
+      return (error as any).result
+    }
     return error.message
   }
 


### PR DESCRIPTION
Fixes #652.

`apollo-link-http` will return a "result" object (if it can) inside its error object. This result object will have details from the GraphQL server about the error.

This PR adds simple logic to `extractMessage` to return that result JSON up to the UI.

It may be prudent in the future to add logic to extract data from the myriad of different Apollo Link errors (https://github.com/apollographql/apollo-link/blob/a79f47e8ae81ee2444d547315be61dbafea37dcb/packages/apollo-link-http-common/src/index.ts#L14-L29), but for now this should suffice.