### PR TITLE
Fix custom theme and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can easily share your Playgrounds with others by clicking on the "Share" but
  <img src="https://camo.githubusercontent.com/daf8c64dbde3097fdbe782c0645552550d530a73/68747470733a2f2f696d6775722e636f6d2f48316e36346c4c2e706e67" alt="" data-canonical-src="https://imgur.com/H1n64lL.png" style="max-width:100%;">
 </a>
 
-> You can also find the announcement blog post [here(https://blog.graph.cool/introducing-graphql-playground-f1e0a018f05d).
+> You can also find the announcement blog post [here](https://blog.graph.cool/introducing-graphql-playground-f1e0a018f05d).
 
 ## Settings
 

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -511,10 +511,11 @@ class PlaygroundWrapper extends React.Component<
   }
 }
 
-const mapStateToProps = createStructuredSelector({
-  theme: getTheme,
-  settings: getSettings,
-})
+const mapStateToProps = (state, ownProps) => {
+  const theme = ownProps.theme || getTheme(state)
+  const settings = ownProps.settings || getSettings(state)
+  return { theme, settings }
+}
 
 export default connect(
   mapStateToProps,

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -20,7 +20,6 @@ import {
 import OldThemeProvider from './Theme/ThemeProvider'
 import { getActiveEndpoints } from './util'
 import { ISettings } from '../types'
-import { createStructuredSelector } from 'reselect'
 import { connect } from 'react-redux'
 import { getTheme, getSettings } from '../state/workspace/reducers'
 import { Session, Tab } from '../state/sessions/reducers'

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -512,7 +512,7 @@ class PlaygroundWrapper extends React.Component<
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const theme = ownProps.theme || getTheme(state)
+  const theme = ownProps.theme || getTheme(state, ownProps.settings)
   const settings = ownProps.settings || getSettings(state)
   return { theme, settings }
 }

--- a/packages/graphql-playground-react/src/state/workspace/reducers.ts
+++ b/packages/graphql-playground-react/src/state/workspace/reducers.ts
@@ -204,7 +204,7 @@ export function normalizeSettingsString(settingsString) {
   return JSON.stringify(parseSettingsString(settingsString), null, 2)
 }
 
-export const getTheme = createSelector(
-  [getSettings],
-  s => s['editor.theme'] || 'dark',
-)
+export const getTheme = (state, customSettings) => {
+  const settings = customSettings || getSettings(state)
+  return settings['editor.theme'] || 'dark'
+}


### PR DESCRIPTION
Fixes #758.

Changes proposed in this pull request:

- Refactor mapStateToProps of PlaygroundWrapper connect to allow custom settings & theme props

- Update getTheme of workspace reducers to use custom settings for theme selection if provided
