### PR TITLE
Add support for deferred queries

### DIFF
--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -119,7 +119,8 @@
   },
   "dependencies": {
     "apollo-link": "^1.0.7",
-    "apollo-link-http": "^1.3.2",
+    "apollo-link-http": "alpha",
+    "apollo-link-patch": "alpha",
     "apollo-link-ws": "1.0.8",
     "calculate-size": "^1.1.1",
     "classnames": "^2.2.5",

--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -2,6 +2,7 @@ import { ApolloLink, execute } from 'apollo-link'
 import { parseHeaders } from '../../components/Playground/util/parseHeaders'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { HttpLink } from 'apollo-link-http'
+import { DeferPatchLink } from 'apollo-link-patch'
 import { WebSocketLink } from 'apollo-link-ws'
 import { isSubscription } from '../../components/Playground/util/hasSubscription'
 import {
@@ -67,11 +68,13 @@ export const defaultLinkCreator = (
     connectionParams = { ...headers }
   }
 
-  const httpLink = new HttpLink({
-    uri: session.endpoint,
-    headers,
-    credentials,
-  })
+  const httpLink = new DeferPatchLink().concat(
+    new HttpLink({
+      uri: session.endpoint,
+      headers,
+      credentials,
+    }),
+  )
 
   if (!(wsEndpoint || subscriptionEndpoint)) {
     return { link: httpLink }

--- a/packages/graphql-playground-react/yarn.lock
+++ b/packages/graphql-playground-react/yarn.lock
@@ -224,12 +224,18 @@ apollo-link-http-common@^0.2.4:
   dependencies:
     apollo-link "^1.2.2"
 
-apollo-link-http@^1.3.2:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
+apollo-link-http@alpha:
+  version "1.6.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.6.0-alpha.5.tgz#1b50e34304a2f29a669a754fac0fcdec14f23ca7"
   dependencies:
     apollo-link "^1.2.2"
     apollo-link-http-common "^0.2.4"
+
+apollo-link-patch@alpha:
+  version "0.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/apollo-link-patch/-/apollo-link-patch-0.1.0-alpha.1.tgz#57084c31efc462c53f1009a81128654da7dedd45"
+  dependencies:
+    apollo-link "^1.2.2"
 
 apollo-link-ws@1.0.8:
   version "1.0.8"


### PR DESCRIPTION
Changes proposed in this pull request:

- Add support for running deferred queries with `@defer`
Changes are minimal, all I had to do was upgrade `apollo-link-http` to deal with multipart responses, and add `apollo-link-patch` to the link chain that handles patching the deferred fields as they stream in.  
